### PR TITLE
There was no way to delete redirects in Craft 4

### DIFF
--- a/src/templates/redirects.twig
+++ b/src/templates/redirects.twig
@@ -61,7 +61,9 @@
 {% endblock %}
 
 {% block footer %}
+    <div id="count-spinner" class="spinner small hidden"></div>
     <div id="count-container" class="light flex-grow">&nbsp;</div>
+    <div id="actions-container" class="flex"></div>
 {% endblock %}
 
 {% block initJs %}


### PR DESCRIPTION
I added the default footer from craft 4 to enable the menu